### PR TITLE
add ls -lX option to show human-readable size

### DIFF
--- a/bin/mantash
+++ b/bin/mantash
@@ -410,6 +410,8 @@ class Mantash(cmdln.Cmdln):
         help="display a '/' after a directory name")
     @cmdln.option("-j", "--json", action="store_true",
         help="display the listing in JSON")
+    @cmdln.option("-X", "--human", action="store_true", dest="human",
+        help="display human-readable sizes")
     def do_ls(self, subcmd, opts, *paths):
         """list objects, directories and links
 
@@ -446,19 +448,28 @@ class Mantash(cmdln.Cmdln):
                 print "%s:" % path
             for name, dirent in sorted(dirents.iteritems()):
                 self._ls_print_dirent(name, dirent, long=opts.long,
-                    format=opts.format)
+                    format=opts.format, human=opts.human)
         if opts.json:
             print json.dumps(listing, indent=2)
         return retval
 
-    def _ls_print_dirent(self, name, dirent, long=False, format=False):
+    def _ls_print_dirent(self, name, dirent,
+      long=False, format=False, human=False):
         if format:
             name += {
                 "directory": "/",
                 "link": "@"
             }.get(dirent["type"], "")
         if long:
+            if human:
+                dirent_fmt = "%9s  %s  %04s  %24s  %s"
+            else:
+                dirent_fmt = "%9s  %s  %8s  %24s  %s"
+
             sz = dirent.get("size", '-')
+            if (sz != "-" and human):
+                sz = self._ls_readable_size(sz)
+
             # Note: Don't have a strong reason to show the "asctime"
             # format here, rather than just parroting the RFC 3339
             # format. IOW, if others have opinions on the time format here,
@@ -467,10 +478,28 @@ class Mantash(cmdln.Cmdln):
             if "mtime" in dirent:
                 mtime = time.asctime(
                     time.strptime(dirent["mtime"], "%Y-%m-%dT%H:%M:%SZ"))
-            print "%9s  %s  %8s  %24s  %s" % (
+            print dirent_fmt % (
                 dirent.get("type", "unknown"), self.user, sz, mtime, name)
         else:
             print name
+
+    def _ls_readable_size(self, bytes):
+        suffixes = [ '', 'K', 'M', 'G', 'T', 'P', 'E' ]
+
+        size = float(bytes)
+        order = 0
+
+        while (size >= 1024):
+            size /= 1024
+            order += 1
+
+	# If size < 10, show a single decimal value.  Otherwise don't show any.
+        if (size < 10):
+            size = '%.1f' % size
+        else:
+            size = '%d' % size
+
+        return size + suffixes[order]
 
     def do_cd(self, subcmd, opts, directory='~'):
         """change directory


### PR DESCRIPTION
For this new option, I used -X (extended?) to show the size since `ls -lh` was conflicting with the top-level -h option.  Trent, I'll leave it to you to resolve the -h collision.

Here's an example of ls -lX:

```
[https://manta-beta.joyentcloud.com/bpijewski/public/mantash_test]$ ls -l
   object  bpijewski  1719664640  Sat Jan  5 01:58:16 2013  1.7g-file
   object  bpijewski    102400  Sat Jan  5 01:58:17 2013  100k-file
   object  bpijewski     10240  Sat Jan  5 01:58:18 2013  10k-file
   object  bpijewski  1073741824  Sat Jan  5 01:58:43 2013  1g-file
   object  bpijewski      1024  Sat Jan  5 01:58:44 2013  1k-file
   object  bpijewski   1048576  Sat Jan  5 01:58:45 2013  1m-file
   object  bpijewski  209715200  Sat Jan  5 01:58:50 2013  200m-file
   object  bpijewski       512  Sat Jan  5 01:58:51 2013  512-file
   object  bpijewski   5242880  Sat Jan  5 01:58:52 2013  5m-file
[https://manta-beta.joyentcloud.com/bpijewski/public/mantash_test]$ ls -lX
   object  bpijewski  1.6G  Sat Jan  5 01:58:16 2013  1.7g-file
   object  bpijewski  100K  Sat Jan  5 01:58:17 2013  100k-file
   object  bpijewski   10K  Sat Jan  5 01:58:18 2013  10k-file
   object  bpijewski  1.0G  Sat Jan  5 01:58:43 2013  1g-file
   object  bpijewski  1.0K  Sat Jan  5 01:58:44 2013  1k-file
   object  bpijewski  1.0M  Sat Jan  5 01:58:45 2013  1m-file
   object  bpijewski  200M  Sat Jan  5 01:58:50 2013  200m-file
   object  bpijewski   512  Sat Jan  5 01:58:51 2013  512-file
   object  bpijewski  5.0M  Sat Jan  5 01:58:52 2013  5m-file
```
