### PR TITLE
Add support for running python-manta internally, on Manta itself

### DIFF
--- a/manta/client.py
+++ b/manta/client.py
@@ -125,8 +125,15 @@ class RawMantaClient(object):
     @param verbose {bool} Optional. Default false. If true, then will log
         debugging info.
     """
-    def __init__(self, url, account, sign=None, signer=None, internal=False, 
-            user_agent=None, cache_dir=None,
+
+    def __init__(self, 
+            url=os.environ.get('MANTA_URL', '').rstrip('/'), 
+            account=os.environ.get('MANTA_USER'), 
+            sign=None, 
+            signer=None, 
+            internal=False, 
+            user_agent=None, 
+            cache_dir=None,
             disable_ssl_certificate_validation=False,
             verbose=False):
         assert account, 'account'


### PR DESCRIPTION
Sometimes it's useful to access Manta in a compute step, e.g. when you want to customize output and `mpipe` isn't cutting it. When in a compute step, you're already implicitly authenticated and so there's no need to sign the request – so the client shouldn't complain when you don't provide a signature or signer.

Tested and works for me.

(Pony: also, it would be nice to have this package installed by default on compute instances. :-))
