### PR TITLE
Fix ssh pub key parsing to remove comment portion

### DIFF
--- a/manta/auth.py
+++ b/manta/auth.py
@@ -58,7 +58,7 @@ def fingerprint_from_ssh_pub_key(data):
     # - the full ssh pub key file content, e.g.:
     #   'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAA...2l24uq9Lfw== my comment'
     if (re.search(r'^ssh-(?:rsa|dss) ', data)):
-        data = data.split(None, 1)[1]
+        data = data.split(None, 2)[1]
 
     key = base64.b64decode(data)
     fp_plain = hashlib.md5(key).hexdigest()

--- a/manta/client.py
+++ b/manta/client.py
@@ -704,6 +704,8 @@ class MantaClient(RawMantaClient):
             method to which to write
         """
         assert mdir.startswith('/'), "%s: invalid manta path" % mdir
+        if not mdir.endswith('/'):
+            mdir += '/'
         parts = mdir.split('/')
         assert len(parts) > 3, "%s: cannot create top-level dirs" % mdir
         if not parents:


### PR DESCRIPTION
When using the PrivateKeySigner for auth, fingerprint_from_ssh_pub_key() doesn't completely parse the SSH pub key correctly (it's leaving the comment if there is one).  This results in a bad fingerprint and subsequent error.


 