### PR TITLE
Updated setup.py to fix links on PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
 is Joyent's object storage service with integrate compute.  This module
 provides a Python 'manta' package and a 'mantash' (MANTA SHell) CLI and
 shell. The project is `hosted on GitHub
-<https://github.com/trentm/python-manta#readme>`_.  Please `file any
-issues here <https://github.com/trentm/python-manta/issues>`_.
+<https://github.com/joyent/python-manta#readme>`_.  Please `file any
+issues here <https://github.com/joyent/python-manta/issues>`_.
 """,
     author="Joyent",
     author_email="support@joyent.com",


### PR DESCRIPTION
Both the Github and Issues links on PyPi https://pypi.python.org/pypi/manta/2.4.0 were pointing at @trentm 's repository https://github.com/trentm/python-manta which give 404 errors now.