### PR TITLE
Support SHA256 key ids (and fix stale tests)

### DIFF
--- a/manta/client.py
+++ b/manta/client.py
@@ -751,7 +751,7 @@ class MantaClient(RawMantaClient):
             #       i=6 -> d: /trent/stor/builds/a/b
             #       i=7 -> d: /trent/stor/builds/a/b/c
             end = len(parts) + 1
-            start = 4 # Index of the first possible dir to create.
+            start = 3 # Index of the first possible dir to create.
             while start < end - 1:
                 idx = (end - start) / 2 + start
                 d = '/'.join(parts[:idx])

--- a/test/test_mantash.py
+++ b/test/test_mantash.py
@@ -33,17 +33,18 @@ class OptionsTestCase(MantaTestCase):
         self.assertEqual(code, 0)
 
     def test_help(self):
+        no_man_pages = "No manual entry for mlogin\nNo manual entry for msign\n"
         code, stdout, stderr = self.mantash(['help'])
         self.assertTrue("mantash help" in stdout)
-        self.assertEqual(stderr, "")
+        self.assertIn(stderr, ("", no_man_pages))
         self.assertEqual(code, 0)
         code, stdout, stderr = self.mantash(['--help'])
         self.assertTrue("mantash help" in stdout)
-        self.assertEqual(stderr, "")
+        self.assertIn(stderr, ("", no_man_pages))
         self.assertEqual(code, 0)
         code, stdout, stderr = self.mantash(['-h'])
         self.assertTrue("mantash help" in stdout)
-        self.assertEqual(stderr, "")
+        self.assertIn(stderr, ("", no_man_pages))
         self.assertEqual(code, 0)
 
 class FindTestCase(MantaTestCase):


### PR DESCRIPTION
Newer versions of ssh-keygen write out SHA256 key fingerprints by default. The node.js client for Manta supports using the SHA256 fingerprint to identify the key but then canonicalizes the fingerprint to MD5 (ref https://github.com/joyent/node-smartdc-auth/pull/3). This PR uses the same method.

In order to verify this fix, I also had to fix two areas that were together causing all tests to fail:

- The minimum index into the directory parts list for `mkdirp` had an off-by-one error, which means that the `/:account/stor/tmp` directory was being skipped over and never being created. This caused the entire test suite to fail.
- The test suite assumed that the user has the `man` pages for `mlogin` and `msign` installed, but doesn't assert this is the case. They aren't installed as part of the base `node-manta` install and honestly I'm not even sure where to find them, so I've removed the assumption from the test of the help flags for mantash.

@trentm I didn't open a JIRA ticket for this because the library doesn't look like it's part of our core supported work based on the number of open issues. But I needed this fix sooner rather than later for the work I'm doing on the [`triton-mysql` blueprint](https://github.com/tgross/triton-mysql/tree/working) so rather than bothering you with this I just knocked it out on my own. Hope that's ok? If so, would you mind giving it a quick look to see if you're happy with it?

cc @misterbisson 