### PR TITLE
Support RBAC

### DIFF
--- a/bin/mantash
+++ b/bin/mantash
@@ -107,6 +107,7 @@ class Mantash(cmdln.Cmdln):
 
         export MANTA_URL=https://us-east.manta.joyent.com
         export MANTA_USER=jill
+        export MANTA_SUBUSER=optional
         export MANTA_KEY_ID=`ssh-keygen -l -f ~/.ssh/id_rsa.pub | awk '{print $2}' | tr -d '\\n'`
         export MANTASH_PS1='\e[90m[\u@\h \e[34m\w\e[90m]$\e[0m '
 
@@ -131,6 +132,13 @@ class Mantash(cmdln.Cmdln):
         parser.add_option("-a", "--account", dest="account",
             help="Manta account (login name). Environment: MANTA_USER=ACCOUNT",
             default=os.environ.get("MANTA_USER"))
+        parser.add_option("--user", "--subuser", dest="subuser",
+            help="Manta user (login name). Environment: MANTA_SUBUSER=USER",
+            default=os.environ.get("MANTA_SUBUSER", None))
+        parser.add_option("--role", dest="role",
+                          help=("Assume a role. Use multiple times or once with "
+                                "a list. Environment: MANTA_ROLE=ROLE,ROLE..."),
+            default=os.environ.get("MANTA_ROLE", None))
         parser.add_option("-k", "--keyId", dest="key_id",
             help="SSH key fingerprint (or path to private key file). See "
                 "note below. Environment: MANTA_KEY_ID=FINGERPRINT",
@@ -184,6 +192,9 @@ class Mantash(cmdln.Cmdln):
         self.host = urlparse(self.manta_url).hostname
 
         self.account = self.options.account
+        self.subuser = self.options.subuser
+        self.role = self.options.role
+
         self.home = "/%s/stor" % self.account
         self.last_cwd = self.cwd = self.home
         if no_auth:
@@ -191,6 +202,8 @@ class Mantash(cmdln.Cmdln):
         else:
             signer = manta.CLISigner(self.options.key_id)
         self.client = manta.MantaClient(self.manta_url, self.account,
+            subuser=self.subuser,
+            role=self.role,
             signer=signer,
             disable_ssl_certificate_validation=self.options.insecure,
             user_agent=USER_AGENT, verbose=self.options.verbose)

--- a/manta/auth.py
+++ b/manta/auth.py
@@ -5,7 +5,7 @@
 import binascii
 import sys
 import os
-from os.path import exists, expanduser, join, dirname, abspath
+from os.path import expanduser
 import logging
 import base64
 import hashlib

--- a/manta/client.py
+++ b/manta/client.py
@@ -199,9 +199,9 @@ class RawMantaClient(object):
                 headers["Date"] = http_date()
             sigstr = 'date: ' + headers["Date"]
             algorithm, fingerprint, signature = self.signer.sign(sigstr)
-            auth = ('Signature keyId="/{}/keys/{}",algorithm="{}",signature="{}"'
-                    .format('/'.join(filter(None, [self.account, self.subuser])),
-                            fingerprint, algorithm, signature))
+            auth = 'Signature keyId="/%s/keys/%s",algorithm="%s",signature="%s"'\
+                   % ('/'.join(filter(None, [self.account, self.subuser])),
+                      fingerprint, algorithm, signature)
             headers["Authorization"] = auth
 
             if self.role:

--- a/manta/client.py
+++ b/manta/client.py
@@ -5,10 +5,10 @@
 import sys
 import logging
 import os
-from os.path import exists, join
+from os.path import exists
 from posixpath import join as ujoin, dirname as udirname, basename as ubasename
 import json
-from pprint import pprint, pformat
+from pprint import pformat
 from operator import itemgetter
 import hashlib
 import datetime

--- a/manta/client.py
+++ b/manta/client.py
@@ -121,6 +121,8 @@ class RawMantaClient(object):
 
     @param url {str} The Manta URL
     @param account {str} The Manta account (login name).
+    @param subuser {str} Optional. The Manta sub user (login name).
+    @param role {str} Optional. The Manta RBAC role.
     @param signer {Signer instance} A python-manta Signer class instance
         that handles signing request to Manta using the http-signature
         auth scheme.
@@ -131,16 +133,18 @@ class RawMantaClient(object):
     @param verbose {bool} Optional. Default false. If true, then will log
         debugging info.
     """
-    def __init__(self, url, account, sign=None, signer=None,
-            user_agent=None, cache_dir=None,
-            disable_ssl_certificate_validation=False,
-            verbose=False):
+    def __init__(self, url, account, subuser=None, role=None, sign=None,
+                 signer=None, user_agent=None, cache_dir=None,
+                 disable_ssl_certificate_validation=False,
+                 verbose=False):
         assert account, 'account'
         if url.endswith('/'):
             self.url = url[:-1]
         else:
             self.url = url
         self.account = account
+        self.subuser = subuser
+        self.role = role
         self.signer = signer or sign
         self.cache_dir = cache_dir or DEFAULT_HTTP_CACHE_DIR
         self.user_agent = user_agent or DEFAULT_USER_AGENT
@@ -195,9 +199,13 @@ class RawMantaClient(object):
                 headers["Date"] = http_date()
             sigstr = 'date: ' + headers["Date"]
             algorithm, fingerprint, signature = self.signer.sign(sigstr)
-            headers["Authorization"] = \
-                'Signature keyId="/%s/keys/%s",algorithm="%s",signature="%s"' % (
-                    self.account, fingerprint, algorithm, signature)
+            auth = ('Signature keyId="/{}/keys/{}",algorithm="{}",signature="{}"'
+                    .format('/'.join(filter(None, [self.account, self.subuser])),
+                            fingerprint, algorithm, signature))
+            headers["Authorization"] = auth
+
+            if self.role:
+                headers['Role'] = self.role
 
         return http.request(url, method, ubody, headers)
 

--- a/test/common.py
+++ b/test/common.py
@@ -31,6 +31,8 @@ def stor(*subpaths):
 class MantaTestCase(unittest.TestCase):
     def __init__(self, *args):
         self.account = os.environ["MANTA_USER"]
+        self.subuser = os.environ.get("MANTA_SUBUSER", None)
+        self.role = os.environ.get("MANTA_ROLE", None)
         unittest.TestCase.__init__(self, *args)
 
     _client = None
@@ -42,6 +44,8 @@ class MantaTestCase(unittest.TestCase):
             signer = manta.CLISigner(key_id=MANTA_KEY_ID)
             self._client = manta.MantaClient(url=MANTA_URL,
                 account=self.account,
+                subuser=self.subuser,
+                role=self.role,
                 signer=signer,
                 # Uncomment this for verbose client output for test run.
                 #verbose=True,

--- a/test/common.py
+++ b/test/common.py
@@ -8,7 +8,6 @@ __all__ = ["stor", "MantaTestCase"]
 import sys
 import os
 from posixpath import join as ujoin
-from pprint import pprint
 import unittest
 import subprocess
 from subprocess import PIPE

--- a/test/test.py
+++ b/test/test.py
@@ -4,7 +4,7 @@
 """The python-manta test suite entry point."""
 
 import os
-from os.path import exists, join, abspath, dirname, normpath
+from os.path import abspath, dirname
 import sys
 import logging
 

--- a/test/test_mantaclient.py
+++ b/test/test_mantaclient.py
@@ -3,15 +3,8 @@
 
 """Test the python-manta MantaClient."""
 
-import os
-import sys
 import re
 from posixpath import dirname as udirname, basename as ubasename, join as ujoin
-from pprint import pprint, pformat
-import unittest
-import codecs
-
-from testlib import TestError, TestSkipped, tag
 
 from common import *
 import manta

--- a/test/test_mantaclient.py
+++ b/test/test_mantaclient.py
@@ -117,6 +117,12 @@ class ObjectTestCase(MantaTestCase):
 class LinkTestCase(MantaTestCase):
     def test_put(self):
         client = self.get_client()
+        if client.subuser or client.role:
+            print('\nSkipping LinkTestCase because a subuser or role has been '
+                  'provided for the Manta client.\nSee '
+                  'https://devhub.joyent.com/jira/browse/MANTA-2829 '
+                  'for details.')
+            return
         client.mkdirp(stor(TDIR))
         obj_path = stor(TDIR, 'obj.txt')
         content = 'foo\nbar\nbaz'

--- a/test/test_mantash.py
+++ b/test/test_mantash.py
@@ -3,18 +3,10 @@
 
 """Test mantash."""
 
-import os
-import sys
 import re
 from posixpath import join as ujoin
-from pprint import pprint
-import unittest
-
-from testlib import TestError, TestSkipped, tag
 
 from common import MantaTestCase, stor
-import manta
-
 
 
 #---- globals


### PR DESCRIPTION
For https://github.com/joyent/python-manta/issues/25, in support of https://github.com/tgross/triton-mysql/tree/working

Update the client to support roles and subusers:

- The `MantaClient` constructor now takes optional `subuser` and `role` parameters and adds these values to the `Authorization` and `Role` headers, respectively.
- The mantash CLI gets the params from either the `--user` / `--role` command line arguments or from the `MANTA_SUBUSER` / `MANTA_ROLE` environment vars. This behavior matches the Node.js Manta client.
- README is updated with instructions for setting up a Manta subuser for tests.

@trentm this is probably ready for review but not a merge yet -- there's one test that I can't get to pass with a subuser, which is the snaplink test. But I've discovered I can't get that test to work with the node client either. I'm investigating that now.

cc @misterbisson 