### PR TITLE
Removed MantaError when content passed to put_object is not str

### DIFF
--- a/manta/client.py
+++ b/manta/client.py
@@ -363,9 +363,6 @@ class RawMantaClient(object):
         else:
             content = file.read()
 
-        if not isinstance(content, str):
-            raise errors.MantaError("'content' must be str, not bytes")
-
         try:
             # python 3
             content_bytes = bytes(content, encoding='utf-8')


### PR DESCRIPTION
We cannot expect to pass the contents of arbitrary binary files as utf-8 strings.

Removed MantaError when content passed to put_object is not str. We're expecting bytes here. if utf-8 str is passed, it will be decoded in the try-catch.

@deserat I've tested that on both Py2 and Py3, as well as manually run a couple of use cases, but if you see any incompatibility with your recent work on Py3 compatibility, please let me know, and I will update accordingly.