### PR TITLE
Fixed a bug in which debug logging of a request with body longer than…

### DIFF
--- a/manta/client.py
+++ b/manta/client.py
@@ -82,9 +82,9 @@ class MantaHttp(httplib2.Http):
     def _request(self, conn, host, absolute_uri, request_uri, method, body,
                  headers, redirections, cachekey):
         if log.isEnabledFor(logging.DEBUG):
-            body_str = body or '(none)'
-            if body and len(body) > 1024:
-                body_str = body[:1021] + '...'
+            body_str = body.decode('utf-8', 'backslashreplace') if body is not None else '(none)'
+            if len(body_str) > 1024:
+                body_str = body_str[:1021] + '...'
             log.debug("req: %s %s\n%s",
                       method,
                       request_uri,


### PR DESCRIPTION
… 1024 bytes raised a TypeError while trying to concat bytes to str. Now body of the request is decoded into a utf-8 str with incorrect bytes being backslash-replaced. Since the body_str is used for debugging only, this should be enough.

Tested with and without TEST_DEBUG in env. We probably should include that in the docs on Development and Testing, btw.