### PR TITLE
Rolling back and using `self._prompt_str` instead of `self.prompt` in…

### DIFF
--- a/manta/cmdln.py
+++ b/manta/cmdln.py
@@ -340,13 +340,13 @@ class RawCmdln(cmd.Cmd):
                 else:
                     if self.use_rawinput:
                         try:
-                            line = input(self._str(self.prompt))
+                            line = input(self._str(self._prompt_str))
                         except EOFError:
                             line = 'EOF'
                         except KeyboardInterrupt:
                             line = 'KeyboardInterrupt'
                     else:
-                        self.stdout.write(self._str(self.prompt))
+                        self.stdout.write(self._str(self._prompt_str))
                         self.stdout.flush()
                         line = self.stdin.readline()
                         if not len(line):


### PR DESCRIPTION
… https://github.com/joyent/python-manta/blob/feature/python3/manta/cmdln.py#L343 in order to properly use `MANTASH_PS1` envvar. Should address @trentm 's https://github.com/joyent/python-manta/issues/28#issuecomment-253925559.