### PR TITLE
Fix UnicodeEncodeError with non-latin chars in location header

### DIFF
--- a/manta/client.py
+++ b/manta/client.py
@@ -94,6 +94,9 @@ class MantaHttp(httplib2.Http):
                           #_indent("cachekey: " + pformat(cachekey)), #XXX
                           _indent("body: " + body_str)
                       ]))
+
+        if 'location' in headers:
+            headers['location'] = urlquote(headers['location'])
         res, content = httplib2.Http._request(self, conn, host, absolute_uri,
                                               request_uri, method, body,
                                               headers, redirections, cachekey)


### PR DESCRIPTION
@deserat urlquote-ing location header in MantaHttp._request to fix UnicodeEncodeError when constructing a request for an object with non-latin characters