### PR TITLE
bump httplib2 dependency to upstream latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pycrypto == 2.6
 paramiko >= 1.7.7.2
-httplib2 == 0.8
+httplib2 == 0.11.3


### PR DESCRIPTION
This dependency (or some certs it pulls along from the ride) has bitrotted to
the point that the cert for us-east.manta.joyent.com can no longer be verified.
From the httplib2 changelog, most of the changes have been updating certs, minor
fixes and the little thing called 'heartbleed'

fixes #48